### PR TITLE
bug fix creating floating dots

### DIFF
--- a/src/calm.js
+++ b/src/calm.js
@@ -243,8 +243,10 @@ export default {
 			.attrTween('stroke-dasharray', this.tweenPathIn)
 			.each('end', function () {
 				let l = this.getTotalLength();
+				// this string matches the first one given in tweenPathOut
+				// needs six parameters so as not to overlap when pathLength < .5 and show a dot for 0
 				d3.select(this)
-					.attr('stroke-dasharray', '0 0 '+ pathLength * l, '0 '+ l +' '+ pathLength * l);
+					.attr('stroke-dasharray', '0 0 '+ pathLength * l + ' 0 0 ' + l);
 			})
 		.transition()
 			.duration((1 - pathLength / (1 + pathLength)) * duration)
@@ -266,17 +268,16 @@ export default {
 		let l = this.getTotalLength(),
 			pl = parseFloat(this.getAttribute('pathlen')),
 			interpolator = d3.interpolateString('0 '+ l, pl * l +' '+ l);
-
 		return t => interpolator(t);
 
 	},
 
 	tweenPathOut: function () {
 
-		// `this` is the SVG path being tweened in spawnPath()
+		// `this` is the SVG path being tweened in spawnPath(), pl is % of total length
 		let l = this.getTotalLength(),
 			pl = parseFloat(this.getAttribute('pathlen')),
-			interpolator = d3.interpolateString('0 0 '+ pl * l, '0 '+ l +' 0');
+			interpolator = d3.interpolateString('0 0 '+ pl * l + ' 0 0 ' + l, '0 ' + l + ' ' + pl * l + ' 0 0 ' + l);
 
 		return t => interpolator(t);
 


### PR DESCRIPTION
Floating dots were appearing because:
(1) "0 0 x" dasharray becomes effectively "0 0 x 0 0 x" 
(2) pathlength percent was < ~50%, so the pattern was repeating more than once a long the path

So, some of the 0's are showing as "visible" dashes. If the stroke linecaps weren't round, this would be fine. But, a 0 length dash with a round linecap becomes a circle/dot. 

Fix was to fully define the dasharray after the first transition ends with a length 6 array of the form "0, x, path length \* length, 0, 0, length". x starts at 0, and is interpolated to length. Because of the 6th element is the full length, this guarantees that we won't repeat the dash-array sequence more than once on the screen.
