### PR TITLE
rip out state for down arrow, and give soft enter on section changes

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -151,11 +151,12 @@ a:active {
 
 @keyframes stretch {
   0% {
-    transform: scale(.5);
-		opacity: .3;
+		opacity: 0;
   }
+	70% {
+		opacity: 0;
+	}
   100% {
-    transform: scale(1);
 		opacity: 1;
   }
 }
@@ -174,23 +175,16 @@ a:active {
 
 		display: none;
 
-		&.animate {
-			transition-property: opacity, background-color;
-			transition-duration: #{$ui-overlays-duration-out}s;
-			transition-timing-function: ease-in-out;
-
+		&.fadeOutIn {
 			animation-name: stretch;
-			animation-duration: 1s;
-			animation-timing-function: ease-out;
+			animation-duration: 5s;
+			animation-timing-function: ease-in;
 			animation-delay: 0;
-			animation-direction: alternate;
+			animation-direction: normal;
 			animation-iteration-count: infinite;
 			animation-fill-mode: none;
 			animation-play-state: running;
 
-			&.pause {
-				animation-play-state: paused;
-			}
 		}
 
 		&.visible {

--- a/src/App.js
+++ b/src/App.js
@@ -48,9 +48,7 @@ export default function (...initArgs) {
 		recentScrollDeltas = [],				// cache recent scroll delta values to check intentionality of scroll
 		lastScroll = 0,							// timestamp of most recent scroll event
 		hasNavigatedThisScroll = false,			// has already navigated during the current inertia/continuous scroll
-		isNavigating = false,					// currently navigating between emotions or sections
-
-		arrowChangeHistory = []; // keep track of which sections have visible arrow
+		isNavigating = false;				// currently navigating between emotions or sections
 
 
 	function init (containerNode) {
@@ -69,7 +67,6 @@ export default function (...initArgs) {
 		dispatcher.addListener(dispatcher.EVENTS.NAVIGATE, onNavigate);
 		dispatcher.addListener(dispatcher.EVENTS.CHANGE_EMOTION_STATE, onEmotionStateChange);
 		dispatcher.addListener(dispatcher.EVENTS.CHANGE_CALLOUT, onCalloutChange);
-		dispatcher.addListener(dispatcher.EVENTS.RECORD_SECTION_INTERACTION, recordSectionInteraction);
 		window.addEventListener('hashchange', onHashChange);
 
 		// size main container to viewport
@@ -297,6 +294,11 @@ export default function (...initArgs) {
 			}
 		}
 
+		function endFade(){
+			document.querySelector('.attentionArrow').classList.remove("fadeOutIn");
+		}
+		document.querySelector('.attentionArrow').classList.add("fadeOutIn");
+		setTimeout(endFade, 4000);
 		updateArrowVisibility(sectionName);
 
 		if (!section.isInited) {
@@ -917,21 +919,6 @@ export default function (...initArgs) {
 			setScrollbarFractionalOpen(0.0);
 			window.addEventListener('mousemove', onWindowMouseMove);
 		}
-	}
-
-	function recordSectionInteraction (sectionName) {
-
-		function stopAnimate(){
-			document.querySelector('.attentionArrow').classList.remove("animate");
-		};
-
-		if(arrowChangeHistory.indexOf(sectionName) == -1){
-			arrowChangeHistory.push(sectionName);
-			document.querySelector('.attentionArrow').classList.add("animate");
-			window.setTimeout(stopAnimate, 3000);
-		}
-
-		updateArrowVisibility(sectionName);
 	}
 
 	function updateArrowVisibility (sectionName) {

--- a/src/continents.js
+++ b/src/continents.js
@@ -716,8 +716,6 @@ const continentsSection = {
 			d3.event.stopImmediatePropagation();
 		}
 
-		dispatcher.recordSectionInteraction('continents');
-
 		dispatcher.navigate(dispatcher.SECTIONS.CONTINENTS, continent.id);
 
 	},

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -8,7 +8,6 @@ const dispatcher = {
 		CHANGE_EMOTION_STATE: 'changeEmotionState',
 		CHANGE_CALLOUT: 'changeCallout',
 		MODAL_CHANGE: 'modalChange',
-		RECORD_SECTION_INTERACTION: 'recordSectionInteraction'
 	},
 
 	SECTIONS: {
@@ -99,12 +98,6 @@ const dispatcher = {
 	changeCallout: function (emotion, title, body) {
 
 		this.emit(this.EVENTS.CHANGE_CALLOUT, emotion, title, body);
-
-	},
-
-	recordSectionInteraction: function (sectionName) {
-
-		this.emit(this.EVENTS.RECORD_SECTION_INTERACTION, sectionName);
 
 	},
 

--- a/src/moods.js
+++ b/src/moods.js
@@ -138,8 +138,6 @@ export default {
 		if (!event) { event = d3.event; }
 		event.stopImmediatePropagation();
 
-		dispatcher.recordSectionInteraction('moods');
-
 		this.overlayContainer.classList.add('visible');
 		this.setCallout(true);
 

--- a/src/states.js
+++ b/src/states.js
@@ -1386,10 +1386,7 @@ export default {
 	},
 
 	setHighlightedState: function (state) {
-		// if state is not null, record section interaction for 'actions' or 'states' depending on isBackgrounded value
-		if(state !== null){
-			dispatcher.recordSectionInteraction(this.isBackgrounded ? 'actions' : 'states');
-		}
+
 		this.highlightedState = state;
 		this.displayHighlightedStates(null);
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -52,8 +52,6 @@ export default {
 
 		this.isInited = true;
 
-		this.recordedHitAreasClicked = false;
-
 	},
 
 	initContainers: function (containerNode) {
@@ -709,18 +707,10 @@ export default {
 			d3.event.stopImmediatePropagation();
 		}
 
-		// record that area has been clicked, so can record interaction when all three have been clicked
-		this.recordedHitAreaClicked = true;
-
 		this.setHighlightedHitArea(hitAreaId);
 	},
 
 	setHighlightedHitArea: function (hitAreaId) {
-
-		// check for all three, if so then update arrow, note that it's not 0 indexed
-		if (this.recordedHitAreaClicked){
-			dispatcher.recordSectionInteraction('triggers');
-		}
 
 		this.highlightedHitArea = hitAreaId;
 		this.displayHighlightedHitArea();


### PR DESCRIPTION
This does two things: 

(1) rips out the state for down arrow, where it attracts attention after the user has completed some certain set of actions

(2) removes the arrow and fades it back in softly on transitions between sections. This avoids having a mostly blank page with a down arrow. And, attracts some attention to it, showing that it exists. 
