### PR TITLE
add back button from more pages

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -351,6 +351,37 @@ a:active {
 	}
 }
 
+#more-about {
+	.back-to-atlas {
+		position: relative;
+		bottom: 1em;
+	}
+}
+
+.back-to-atlas {
+	position: absolute;
+	bottom: 1em;
+	display: inline-block;
+	left: 50%;
+	margin: 1em 0em 1em -3.5em;
+
+	border: 1px solid;
+	text-align: center;
+	padding: .2em .4em;
+
+	color: $text-color;
+	background-color: rgba($background-color, 0.5);
+	cursor: pointer;
+
+	h4 {
+		margin: 0;
+	}
+
+	p {
+		margin: 0;
+	}
+}
+
 #modal-overlay {
 	position: absolute;
 	top: 0;

--- a/src/moreInfo.js
+++ b/src/moreInfo.js
@@ -118,12 +118,29 @@ export default {
 
 		containerEl.classList.add('more-child');
 		outerwrapper.classList.add('outer-wrapper');
-		innerwrapper.classList.add('wrapper');
 
 		outerwrapper.appendChild(innerwrapper);
 		containerEl.appendChild(outerwrapper);
 
+		if (id == 'more-about' || id == 'more-annex' || id == 'more-donate' || id == 'more-further') {
+			// add back button for main more pages
+			const innerinnerwrapper = document.createElement('div');
+			innerinnerwrapper.classList.add('wrapper');
+			innerwrapper.appendChild(innerinnerwrapper);
+			this.setBackButton(innerwrapper);
+		} else {
+			innerwrapper.classList.add('wrapper');
+		}
+
 		return containerEl;
+	},
+
+	setBackButton: function(element) {
+		const backToAtlas = document.createElement('div');
+		backToAtlas.innerHTML = "<h4>Back to Atlas</h4>";
+		backToAtlas.classList.add('back-to-atlas');
+		backToAtlas.addEventListener('click', this.onCloseButtonClicked.bind(this));
+		element.appendChild(backToAtlas);
 	},
 
 	initContainers: function() {


### PR DESCRIPTION
Adds a back button from the core 'more' pages back to the atlas. Same behavior as the "x" in the upper right hand corner, but more discoverable and parallels the "visit the annex" link from calm. 
