### PR TITLE
Fix the english y

### DIFF
--- a/static/strings/langs/uk.json
+++ b/static/strings/langs/uk.json
@@ -1602,7 +1602,7 @@
         },
         {
             "key": "disgust_timeline_state_emotion",
-            "value": "огидy",
+            "value": "огиду",
             "english": "disgust"
         },
         {
@@ -2246,7 +2246,7 @@
         },
         {
             "key": "enjoyment_timeline_state_emotion",
-            "value": "втіхy",
+            "value": "втіху",
             "english": "enjoyment"
         },
         {


### PR DESCRIPTION
Accidentally, sone english y characters got into the translation. They have been fixed in the spreadsheet and the strings json.